### PR TITLE
feat: establish TCP connection to endpoint in advance

### DIFF
--- a/src/utils/preconnect.js
+++ b/src/utils/preconnect.js
@@ -1,0 +1,25 @@
+const net = require('net')
+
+/**
+ * Establishes a connection to a host so that we don't have to
+ * spend time on that when we want to execute the job.
+ * The returned socket can be passed to phin via
+ * `createConnection` which is part of http.request() options
+ *
+ * @returns {Function} A createConnection
+ */
+exports.preConnectSocket = async (endpoint) => {
+  const parsedUrl = new URL(endpoint)
+  const {
+    protocol,
+    hostname: host,
+    port: parsedPort,
+  } = parsedUrl
+
+  const port = parsedPort || (protocol === 'https:'
+    ? '443'
+    : '80')
+
+  const netSocket = net.createConnection({ host, port })
+  return () => netSocket
+}

--- a/src/utils/sleep.js
+++ b/src/utils/sleep.js
@@ -1,0 +1,5 @@
+module.exports = exports = async (ms) => {
+  return new Promise((resolve) => {
+    setTimeout(() => resolve(), ms)
+  })
+}


### PR DESCRIPTION
In order to speed up the delivery of our HTTP payloads we can take advantage of the fact that the SQS+Lambda integration will occassionally return messages a bit early. In the margin between SQS and actual `scheduledAt` we can resolve DNS and open a socket to reduce the amount of work that needs to happen once the job is meant to make its HTTP call.